### PR TITLE
Adição do arquivo de notícias no repositório principal

### DIFF
--- a/assets/all_news.json
+++ b/assets/all_news.json
@@ -1,0 +1,733 @@
+{
+  "news": [
+    {
+      "id": 81,
+      "href": "https://www.agazeta.com.br/es/cotidiano/secretario-de-saude-atualiza-situacao-da-pandemia-da-covid-19-no-es-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/11/04/secretario-de-estado-da-saude-nesio-fernandes-em-pronunciamento-nesta-quarta-feira-09-353136.jpeg",
+      "title": "Secretário de Saúde atualiza situação da pandemia da Covid-19 no ES",
+      "date": "28/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 80,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-serra-vai-abrir-vagas-para-vacinar-pessoas-acima-de-35-anos-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/06/15/vacina-covid-19-535944-article.jpg",
+      "title": "Covid: Serra vai abrir vagas para vacinar pessoas acima de 35 anos",
+      "date": "28/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 79,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/25/em-atualizacao-do-mapa-de-risco-vitoria-esta-em-risco-baixo-para-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/fpN4qchYxzBTu6IO6dI6alYQpoU=/0x0:768x425/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/X/q/TKxd3JTUWBKFZpzEy4LQ/resultado-exame-covid.jpg",
+      "title": "Em atualização do mapa de risco, Vitória está em risco baixo para Covid-19",
+      "date": "28/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 78,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/22/es-chega-a-11327-mortes-e-509538-casos-confirmados-de-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/fpN4qchYxzBTu6IO6dI6alYQpoU=/0x0:768x425/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/X/q/TKxd3JTUWBKFZpzEy4LQ/resultado-exame-covid.jpg",
+      "title": "ES chega a 11.327 mortes e 509.538 casos confirmados de Covid-19",
+      "date": "22/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 77,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-cidade-do-es-vacina-moradores-de-35-anos-para-nao-perder-doses-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/03/30/cidade-de-sao-mateus-218154-article.jpg",
+      "title": "Covid: cidade do ES vacina moradores de 35 anos para não perder doses",
+      "date": "22/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 76,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/22/es-antecipa-vacinacao-de-2a-dose-de-astrazeneca-e-notifica-testes-positivos-de-covid-19-por-sms.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/in3xwe_a_Obim8jWCxO88n9c2ps=/0x56:1156x797/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/6/T/4TePOcSgyb5j4AuUV7AQ/whatsapp-image-2021-06-22-at-10.01.28.jpeg",
+      "title": "ES antecipa vacinação de 2ª dose de AstraZeneca e notifica testes positivos de Covid-19 por SMS",
+      "date": "22/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 75,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/16/auditoria-mostra-que-934-pessoas-usaram-documentos-de-mortos-para-se-vacinar-contra-covid-19-no-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/yGQEALi9gv9NoIdItEJFeybbGhY=/0x0:984x535/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/x/J/Vju35wRNATqmGPn5mbqg/esc-vacinacao-19-01-21-cd4710df-1-.jpg",
+      "title": "Auditoria diz que 934 pessoas usaram documentos de mortos na vacinação contra Covid-19 no ES",
+      "date": "17/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 74,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/16/es-comeca-a-testar-passageiros-para-covid-19-no-aeroporto-de-vitoria.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/jlvz3TFWRF9dc3x78zEwee90T6w=/0x0:1920x1080/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2019/e/0/AvYjAMTdqqKG6ZJhjMaw/cancela-voos-avianca-25-04-2019.mov-snapshot-00.05-2019.04.25-09.55.36-.jpg",
+      "title": "ES começa a testar passageiros para Covid-19 no Aeroporto de Vitória",
+      "date": "17/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 73,
+      "href": "https://www.agazeta.com.br/es/obituario/professor-universitario-vanildo-stieg-morre-vitima-da-covid-19-no-es-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/06/16/o-professor-vanildo-stieg-537383-article.jpeg",
+      "title": "Professor universitário Vanildo Stieg morre vítima da Covid-19 no ES",
+      "date": "17/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 72,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/06/04/toda-populacao-de-18-a-49-anos-sera-vacinada-contra-covid-19-em-viana-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/hBywpjsuEVJ7wanzqBJzZ-kn8L0=/0x0:635x425/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/F/I/d8Zk3uTDuWfLpW9xKw2A/casaaaa.jpg",
+      "title": "Toda população de 18 a 49 anos será vacinada contra Covid-19 em Viana, ES",
+      "date": "04/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 71,
+      "href": "https://www.agazeta.com.br/es/cotidiano/governador-anuncia-novidades-na-vacinacao-contra-a-covid-19-no-es-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/01/coletiva-com-o-governador-429121-article.jpg",
+      "title": "Governador anuncia novidades na vacinação contra a Covid-19 no ES",
+      "date": "04/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 70,
+      "href": "https://www.agazeta.com.br/es/cotidiano/vacinacao-em-massa-quando-o-es-sentira-os-efeitos-da-imunidade-coletiva-0621",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/02/22/vacinacao-em-brasilia-423985-article.jpg",
+      "title": "Quando o ES sentirá os efeitos da imunidade coletiva?",
+      "date": "04/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 69,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/05/31/es-chega-a-10798-mortes-e-482137-casos-confirmados-de-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://www.infomoney.com.br/wp-content/uploads/2020/07/GettyImages-1214347515.jpg?w=768&quality=70&strip=all",
+      "title": "ES chega a 10.798 mortes e 482.137 casos confirmados de Covid-19",
+      "date": "01/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 68,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/05/29/mais-de-90-pessoas-isoladas-em-hotel-passam-por-exames-de-covid-19-apos-indiano-testar-positivo-no-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/6-8I8_J5DlaDLAcUVfhgrEmxTP0=/0x0:600x338/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/b/G/cf7EANTJqIjBJ43Ze5pg/hospedee.jpg",
+      "title": "Hóspedes em hotel no ES passam por exames após indiano testar positivo",
+      "date": "01/06/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 67,
+      "href": "https://www.agazeta.com.br/es/cotidiano/cariacica-abre-10-mil-vagas-para-vacinacao-contra-a-covid-nesta-segunda-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/02/04/vacina-de-oxford-413583-article.jpg",
+      "title": "Cariacica abre 10 mil vagas para vacinação nesta segunda",
+      "date": "01/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 66,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-o-que-fazer-para-afastar-o-risco-da-quarta-onda-no-es-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/06/22/empresas-terao-que-adotar-mascaras-no-ambiente-de-trabalhoma-267248-article.jpg",
+      "title": "Covid-19: o que fazer para afastar o risco da quarta onda no ES",
+      "date": "01/06/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 65,
+      "href": "https://www.agazeta.com.br/es/politica/covid-19-no-es-ja-custou-r-1-bilhao-mais-da-metade-foi-gasta-em-leitos-0521",
+      "target": "_blank",
+      "image": "https://cdn.falauniversidades.com.br/wp-content/uploads/2018/07/11142233/pink-money.jpg",
+      "title": "Covid-19 no ES já custou R$ 1 bilhão; mais da metade foi gasta em leitos",
+      "date": "27/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 64,
+      "href": "https://www.agazeta.com.br/es/cotidiano/es-e-notificado-sobre-caso-suspeito-da-variante-indiana-da-covid-19-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/05/10/a-frente-da-secretaria-estadual-de-saude-sesa-esta-o-secretario-nesio-fernandes-490749-article.jpg",
+      "title": "ES é notificado sobre caso suspeito da variante indiana da Covid-19",
+      "date": "27/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 63,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/05/25/es-amplia-vacinacao-contra-covid-19-para-pessoas-com-comorbidade-acima-de-18-anos.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/go5-5P4bbthuu2IHT3A_qviJqAU=/0x0:800x600/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/Q/K/VO85xITWK6nSmP4dxiWQ/videocapture-20210322-095116.jpg",
+      "title": "ES amplia vacinação para pessoas com comorbidade acima de 18 anos",
+      "date": "27/05/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 62,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-es-e-o-7-em-ranking-com-mais-mortes-por-100-mil-habitantes-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/07/leitos-do-hospital-materno-infantil-na-serra-para-pacientes-com-a-covid-19-469235-article.jpg",
+      "title": "Covid-19: ES é o 7° em ranking com mais mortes por 100 mil habitantes",
+      "date": "17/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 61,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/05/14/es-recebe-43800-doses-da-coronavac-e-52250-da-astrazeneca.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/yGQEALi9gv9NoIdItEJFeybbGhY=/0x0:984x535/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/x/J/Vju35wRNATqmGPn5mbqg/esc-vacinacao-19-01-21-cd4710df-1-.jpg",
+      "title": "ES recebe mais doses da CoronaVac e da AstraZeneca",
+      "date": "17/05/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 60,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-18-cidades-do-es-ainda-guardam-vacinas-em-geladeiras-domesticas-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/26/camaras-frias-para-armazenar-vacinas-da-prefeitura-de-cariacica-446252-article.jpeg",
+      "title": "18 cidades do ES ainda guardam vacinas em geladeiras domésticas",
+      "date": "17/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 59,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/05/12/com-10-mil-mortes-por-covid-19-familias-do-es-compartilham-dor-da-perda.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/BkwdlvHoo6mfp--tn_Ly07NWa_8=/0x0:1920x1080/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/4/U/wqCapfSjahoaAAhPO0sA/imagens-covid-mata-mais-21-07-2020.mov-snapshot-00.21-2020.07.29-13.11.40-.jpg",
+      "title": "Com 10 mil mortes por Covid-19, famílias do ES compartilham dor da perda",
+      "date": "13/05/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 58,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid19-todos-os-pacientes-com-hipertensao-agora-podem-ser-vacinados-no-es-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/12/14/jovem-com-hipertensao-pressao-alta-382038-article.jpg",
+      "title": "Covid-19: todos os pacientes com hipertensão agora podem ser vacinados no ES",
+      "date": "13/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 57,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-vitoria-abre-vagas-para-idosos-trabalhadores-da-saude-e-comorbidades-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/27/a-defensoria-publica-esta-recebendo-denuncias-de-problemas-com-a-vacinacao-ou-com-o-processo-de-agendamento-481637-article.jpg",
+      "title": "Vitória abre vagas para idosos, trabalhadores da saúde e comorbidades",
+      "date": "13/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 56,
+      "href": "https://www.agazeta.com.br/es/cotidiano/veja-comprovantes-necessarios-para-gravidas-e-pessoas-com-comorbidade-vacinarem-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/29/mulher-gravida-gravida-gestante-mascara-covid-19-483851-article.jpg",
+      "title": "Veja comprovantes necessários para grávidas e pessoas com comorbidade vacinarem",
+      "date": "04/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 55,
+      "href": "https://www.agazeta.com.br/es/cotidiano/profissional-de-saude-que-trocar-segunda-dose-no-es-sera-punido-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/05/03/vacina-485734-article.jpeg",
+      "title": "Covid-19: profissional que trocar segunda dose no ES será punido, determina secretário",
+      "date": "04/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 54,
+      "href": "https://www.agazeta.com.br/es/cotidiano/grande-vitoria-confira-datas-para-agendamento-de-vacinacao-contra-a-covid-19-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/27/a-defensoria-publica-esta-recebendo-denuncias-de-problemas-com-a-vacinacao-ou-com-o-processo-de-agendamento-481637-article.jpg",
+      "title": "Grande Vitória: confira datas para agendamento de vacinação contra a Covid-19",
+      "date": "04/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 53,
+      "href": "https://www.agazeta.com.br/es/cotidiano/secretario-de-saude-atualiza-situacao-da-pandemia-da-covid-19-no-es-0521",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/11/04/secretario-de-estado-da-saude-nesio-fernandes-em-pronunciamento-nesta-quarta-feira-09-353136.jpeg",
+      "title": "Secretário de Saúde atualiza situação da pandemia da Covid-19 no ES",
+      "date": "04/05/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 52,
+      "href": "https://www.agazeta.com.br/es/cotidiano/queda-de-obitos-no-es-e-esperada-nas-proximas-semanas-diz-secretario-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/01/coletiva-com-o-governador-429121-article.jpg",
+      "title": "\"Queda de óbitos no ES é esperada nas próximas semanas\", diz secretário",
+      "date": "23/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 51,
+      "href": "https://www.agazeta.com.br/es/cotidiano/mapa-de-risco-no-es-confira-onde-pode-ou-nao-ter-aula-presencial-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/10/14/sala-de-aula-338827-article.jpg",
+      "title": "Mapa de Risco no ES: confira onde pode ou não ter aula presencial",
+      "date": "23/04/2021",
+      "source": "Folha Vitória"
+    },
+    {
+      "id": 50,
+      "href": "https://www.folhavitoria.com.br/geral/noticia/04/2021/covid-19-apos-mais-de-um-mes-taxa-de-ocupacao-de-leitos-de-uti-volta-a-ficar-abaixo-dos-90-no-es",
+      "target": "_blank",
+      "image": "https://assets.folhavitoria.com.br/images/49523330-8b15-11eb-863a-a7a89353bcd8--minified.jpg",
+      "title": "Taxa de ocupação de leitos de UTI volta a ficar abaixo dos 90% no ES",
+      "date": "23/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 49,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-cariacica-abre-agendamento-de-vacinacao-para-pessoas-acima-de-60-anos-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/22/profissional-da-saude-aplica-vacina-contra-a-covid-19-478853-article.jpg",
+      "title": "Cariacica agenda de vacinação para pessoas acima de 60 anos",
+      "date": "23/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 48,
+      "href": "https://www.folhavitoria.com.br/geral/noticia/04/2021/es-tem-mais-103-mortes-por-covid-em-24-horas-segunda-maior-marca-desde-o-inicio-da-pandemia",
+      "target": "_blank",
+      "image": "https://assets.folhavitoria.com.br/images/ba661560-87f1-0138-03da-0a58a9feac2a--minified.jpg",
+      "title": "Mais de 103 mortes em 24 horas por Covid-19 no ES",
+      "date": "20/04/2021",
+      "source": "Folha Vitória"
+    },
+    {
+      "id": 47,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-es-bate-recorde-de-pacientes-internados-em-leitos-de-uti-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/22/chegadas-dos-pacientes-com-covid-19-vindos-de-manaus-404764-article.jpg",
+      "title": "Covid-19: ES bate recorde de pacientes internados em leitos de UTI",
+      "date": "20/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 46,
+      "href": "https://www.folhavitoria.com.br/geral/noticia/04/2021/es-pode-ter-quarta-onda-de-casos-de-covid-19-a-partir-de-maio",
+      "target": "_blank",
+      "image": "https://www.infomoney.com.br/wp-content/uploads/2020/07/GettyImages-1214347515.jpg?w=768&quality=70&strip=all",
+      "title": "ES pode ter quarta onda de casos de covid-19 a partir de maio",
+      "date": "20/04/2021",
+      "source": "Folha Vitória"
+    },
+    {
+      "id": 45,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/04/17/covid-19-veja-as-medidas-restritivas-para-cada-grupo-de-cidades-do-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/XgbcQzmEmRO6n40dKau-oW_nKwA=/0x0:854x480/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/W/E/TqG1mCSOKPqoWhUD4ffA/enchente-pandemia-cachoeiro-04-06-20-1d84df2b.jpeg",
+      "title": "Covid-19: veja as medidas restritivas para cada grupo de cidades do ES",
+      "date": "20/04/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 44,
+      "href": "https://www.agazeta.com.br/conteudo-de-marca/novas-tecnologias-auxiliam-no-tratamento-durante-e-pos-covid-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/04/12/com-as-plataformas-exclusivas-do-plano-santa-casa-e-o-uso-de-informacao-e-tecnologia-ja-e-possivel-garantir-um-processo-de-reabilitacao-seguro-e-eficaz-472182-article.jpeg",
+      "title": "Novas tecnologias auxiliam no tratamento durante e pós-Covid",
+      "date": "20/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 43,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-professores-de-50-a-59-anos-serao-os-primeiros-vacinados-no-es-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/10/14/sala-de-aula-338833-article.jpg",
+      "title": "Professores de 50 a 59 anos serão os primeiros vacinados no ES",
+      "date": "15/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 42,
+      "href": "https://www.agazeta.com.br/es/cotidiano/governo-do-es-detalha-plano-de-vacinacao-para-trabalhadores-essenciais-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/22/vacina-coronavac-405100-article.jpg",
+      "title": "Governo detalha plano de vacinação para trabalhadores essenciais",
+      "date": "15/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 41,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/04/12/covid-19-veja-as-medidas-restritivas-para-cada-grupo-de-cidades-do-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/XgbcQzmEmRO6n40dKau-oW_nKwA=/0x0:854x480/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/W/E/TqG1mCSOKPqoWhUD4ffA/enchente-pandemia-cachoeiro-04-06-20-1d84df2b.jpeg",
+      "title": "Veja as medidas restritivas para cada grupo de cidades do ES",
+      "date": "15/04/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 40,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/04/09/covid-19-mes-de-abril-ainda-sera-critico-para-o-es-diz-secretario-de-saude.ghtml",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/06/22/empresas-terao-que-adotar-mascaras-no-ambiente-de-trabalhoma-267248-article.jpg",
+      "title": "Covid-19: abril ainda será crítico para o ES, diz secretário de Saúde",
+      "date": "13/04/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 39,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/04/11/seis-municipios-do-es-nao-tem-mais-estoque-para-primeira-dose-de-vacina-contra-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/yGQEALi9gv9NoIdItEJFeybbGhY=/0x0:984x535/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/x/J/Vju35wRNATqmGPn5mbqg/esc-vacinacao-19-01-21-cd4710df-1-.jpg",
+      "title": "Seis cidades do ES não têm mais estoque de vacina contra Covid-19",
+      "date": "13/04/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 38,
+      "href": "https://www.agazeta.com.br/es/cotidiano/o-que-os-cientistas-ja-sabem-sobre-os-casos-de-reinfeccao-pela-covid-19-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/18/das-10-vacinas-fornecidas-pela-fiocruz-apenas-4-nao-dependem-da-importacao-de-insumos-441177-article.jpg",
+      "title": "O que os cientistas já sabem sobre os casos de reinfecção pela Covid-19",
+      "date": "13/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 37,
+      "href": "https://www.cnnbrasil.com.br/saude/2021/03/30/brasil-e-o-pais-que-mais-registra-mortes-diarias-por-covid-19-em-marco",
+      "target": "_blank",
+      "image": "https://www.infomoney.com.br/wp-content/uploads/2020/07/GettyImages-1214347515.jpg?w=768&quality=70&strip=all",
+      "title": "Brasil lidera número de mortes diárias por Covid-19 no mundo em março",
+      "date": "07/04/2021",
+      "source": "CNN Brasil"
+    },
+    {
+      "id": 36,
+      "href": "https://www.agazeta.com.br/es/cotidiano/es-bate-recorde-com-mais-95-mortes-por-covid-19-em-apenas-24-horas-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/24/covas-abertas-no-cemiterio-de-maruipe-em-vitoria-444734-article.jpg",
+      "title": "Uma morte a cada 15 minutos: ES bate recorde de mortes em 24 horas",
+      "date": "06/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 35,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-es-bate-recorde-e-ultrapassa-marca-de-900-pessoas-em-leitos-de-uti-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/22/chegadas-dos-pacientes-com-covid-19-vindos-de-manaus-404768-article.jpg",
+      "title": "ES bate recorde e ultrapassa marca de 900 pessoas em leitos de UTI",
+      "date": "06/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 34,
+      "href": "https://www.folhavitoria.com.br/geral/noticia/04/2021/secretaria-de-saude-muda-protocolos-de-atendimento-no-es-para-agilizar-testagem-em-massa",
+      "target": "_blank",
+      "image": "https://assets.folhavitoria.com.br/images/7dd6c4f0-2f48-11eb-b63c-8b8aec4fb157--minified.jpg",
+      "title": "Exame de covid-19 em consultas médicas: resultado sai em 20 minutos",
+      "date": "06/04/2021",
+      "source": "Folha Vitória"
+    },
+    {
+      "id": 33,
+      "href": "https://www.agazeta.com.br/es/cotidiano/vacinacao-dos-profissionais-da-seguranca-publica-do-es-comeca-nesta-terca-06-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/03/planalto-serrano-430371-article.jpg",
+      "title": "Vacinação dos profissionais da segurança pública do ES começa hoje",
+      "date": "06/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 32,
+      "href": "/news/fevereiro-timelapse-mapas",
+      "target": "_blank",
+      "image": "https://bn1304files.storage.live.com/y4mqrQxkEwX6SAAs8cegsQPuv4sIM1tUZ2DPSDrPUIuy7lJhSmja6jmWMIuwZ6vOX5fP3Od-o-BcXVlnTrwqA-zj-m84xefxTTLQJVMDrNNAUy6dQ8yl5lcmGIGgMtm1av53UzjzGnxhsF_rmMtcBP6tLKGoYzjqFA7srIJ7rLVIjFm_GHc6dpjyWFNUcuEhx09?width=1920&height=1080&cropmode=none",
+      "title": "Timelapse: Casos de Covid-19 no Espírito Santo em fevereiro",
+      "date": "01/04/2021",
+      "source": "GeoCovid ES"
+    },
+    {
+      "id": 31,
+      "href": "https://www.agazeta.com.br/es/cotidiano/es-vai-receber-1689-mil-doses-de-vacina-e-pode-agilizar-imunizacao-de-idosos-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/30/vacinacao-idosos-profissionais-de-saude-linhares-451094-article.jpg",
+      "title": "ES vai receber 168,9 mil vacinas e pode agilizar imunização de idosos",
+      "date": "01/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 30,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/03/31/marco-termina-com-maior-registro-de-mortes-por-covid-19-em-um-mes-desde-o-inicio-da-pandemia-no-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/BkwdlvHoo6mfp--tn_Ly07NWa_8=/0x0:1920x1080/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/4/U/wqCapfSjahoaAAhPO0sA/imagens-covid-mata-mais-21-07-2020.mov-snapshot-00.21-2020.07.29-13.11.40-.jpg",
+      "title": "Março foi o mês com mais mortes desde o início da pandemia no ES",
+      "date": "01/04/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 29,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-ao-menos-15-gravidas-ja-morreram-da-doenca-no-es-0421",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/21/pacientes-de-manaus-infectados-pelo-coronavirus-chegam-ao-hospital-jayme-dos-santos-neves-404425-article.jpg",
+      "title": "Covid-19: ao menos 15 grávidas já morreram da doença no ES",
+      "date": "01/04/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 28,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/03/26/es-chega-a-96percent-de-ocupacao-de-leitos-de-uti-para-a-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/CQV2uO0ZRdhGwP_o5nXwAkLbJqA=/0x0:854x480/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/r/V/uBGjOATbyRT5VnaqzPxQ/ilustra-rotina-jayme-santos-11-09-2020.jpeg",
+      "title": "ES tem 96% dos leitos de UTI para tratamento de Covid-19 ocupados",
+      "date": "29/03/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 27,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-31-cidades-do-es-tem-taxa-de-mortalidade-acima-da-media-estadual-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/24/covas-abertas-no-cemiterio-de-maruipe-em-vitoria-444731-article.jpg",
+      "title": "Covid-19: 31 cidades do ES têm taxa de mortalidade acima da média estadual",
+      "date": "29/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 26,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/03/26/vitoria-comeca-vacinacao-de-idosos-com-65-anos-neste-sabado.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/yGQEALi9gv9NoIdItEJFeybbGhY=/0x0:984x535/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/x/J/Vju35wRNATqmGPn5mbqg/esc-vacinacao-19-01-21-cd4710df-1-.jpg",
+      "title": "Vitória começa vacinação contra Covid-19 de pessoas com 65 anos",
+      "date": "29/03/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 25,
+      "href": "https://www.agazeta.com.br/es/cotidiano/transmissao-comunitaria-de-variante-e-galopante-no-es-diz-diretor-do-lacen-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/03/14/lacen-es-exames-de-coronavirus-ja-estao-sendo-feitos-no-estado-antes-coletas-eram-enviadas-para-o-rio-de-janeiro-207780-article.jpg",
+      "title": "Sete variantes do novo coronavírus circulam no Espírito Santo",
+      "date": "23/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 24,
+      "href": "https://www.agazeta.com.br/es/cotidiano/secretario-da-saude-atualiza-situacao-da-pandemia-de-covid-19-no-es-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/11/04/secretario-de-estado-da-saude-nesio-fernandes-em-pronunciamento-nesta-quarta-feira-09-353136.jpeg",
+      "title": "Secretário da Saúde atualiza situação da pandemia de Covid-19 no ES",
+      "date": "23/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 23,
+      "href": "https://www.agazeta.com.br/es/politica/es-nao-recebeu-r-16-bilhoes-do-governo-federal-para-combater-a-covid-0321",
+      "target": "_blank",
+      "image": "https://cdn.falauniversidades.com.br/wp-content/uploads/2018/07/11142233/pink-money.jpg",
+      "title": "ES não recebeu R$ 16 bilhões do governo federal para combater a Covid",
+      "date": "23/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 22,
+      "href": "https://www.agazeta.com.br/es/cotidiano/automedicacao-tem-piorado-quadro-de-pacientes-com-covid-19-no-es-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/15/linhares-foi-um-das-cidades-contempladas-com-as-ambulancias-do-samu-438799-article.jpg",
+      "title": "Automedicação tem piorado quadro de pacientes com Covid-19 no ES",
+      "date": "19/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 21,
+      "href": "https://www.agazeta.com.br/es/cotidiano/redes-privada-e-filantropica-pedem-ajuda-ao-estado-para-adquirir-medicamentos-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/03/01/coletiva-com-o-governador-429121-article.jpg",
+      "title": "Redes privada e filantrópica pedem ajuda ao Estado",
+      "date": "19/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 20,
+      "href": "https://www.agazeta.com.br/es/cotidiano/vila-velha-confirma-perda-de-547-doses-de-vacinas-contra-a-covid-19-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/25/chegada-das-vacinas-da-oxfordastrazeneca-a-vila-velha-406905-article.jpg",
+      "title": "Vila Velha confirma perda de 547 doses de vacinas contra a Covid-19",
+      "date": "19/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 19,
+      "href": "https://www.agazeta.com.br/es/cotidiano/entenda-o-que-voce-vai-poder-fazer-ou-nao-durante-a-quarentena-no-es-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/03/18/data-18032020---es---vitoria---coronavirus---movimentacao-de-bares-no-triangulo-das-bermudas-na-praia-do-canto---editoria-cidades---foto-vitor-jubini---gz-210670-article.jpg",
+      "title": "Entenda o que você vai poder fazer ou não durante a quarentena no ES",
+      "date": "17/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 18,
+      "href": "/news/timelapse-mapas-municipios",
+      "target": "_blank",
+      "image": "https://bn1304files.storage.live.com/y4mqrQxkEwX6SAAs8cegsQPuv4sIM1tUZ2DPSDrPUIuy7lJhSmja6jmWMIuwZ6vOX5fP3Od-o-BcXVlnTrwqA-zj-m84xefxTTLQJVMDrNNAUy6dQ8yl5lcmGIGgMtm1av53UzjzGnxhsF_rmMtcBP6tLKGoYzjqFA7srIJ7rLVIjFm_GHc6dpjyWFNUcuEhx09?width=1920&height=1080&cropmode=none",
+      "title": "Veja 1 ANO de casos de Covid-19 no ES em 20 segundos",
+      "date": "16/03/2021",
+      "source": "GeoCovid ES"
+    },
+    {
+      "id": 17,
+      "href": "https://www.agazeta.com.br/es/cotidiano/casagrande-anuncia-medidas-mais-rigidas-para-combate-a-covid-19-no-es-0321?_gl=1*n8pw8m*_ga*a3FibDlTN1FXSl9UeGhxZUhhU1VGMUJ5bHIwbUVGRU1XSnJhOGZ2UFlVVU0xcUYtdUZfREVqZi0xb0plcnpCYw",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/Gow3GMnf-jkpYBm6u44WwnqWkwE=/0x0:985x657/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/q/k/GxEyZTSrKfapYGep25cQ/20210316150942-img-6691.jpg",
+      "title": "Casagrande anuncia medidas mais rígidas para combate à Covid-19 no ES",
+      "date": "16/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 16,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-es-chega-a-91-de-ocupacao-de-leitos-de-uti-nesta-terca-16-0321",
+      "target": "_blank",
+      "image": "https://bn1304files.storage.live.com/y4maETIH5Eq2B95KtGapAYqTVjQDU_-7Hg7_RM1SH0hQC30lbt4CDffy4Hehhz_0bNkdT4r64xsCX9tn8KO6AkR2RZO4sfZfS4qYl764C3z4k_EIgWGHS8cdqoFuTNiII8vvja56hru2XvkevduD4M3PZ6eVIGZIum8GHTVCS3klKAXUEwhnJddEolBGKAQrB3C?width=1920&height=1280&cropmode=none",
+      "title": "Covid-19: ES chega a 91% de ocupação de leitos de UTI",
+      "date": "16/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 15,
+      "href": "https://www.folhavitoria.com.br/geral/noticia/03/2021/novo-mapa-de-risco-entra-em-vigor-com-restricoes-em-17-cidades-saiba-o-que-muda-no-seu-municipio",
+      "target": "_blank",
+      "image": "https://assets.folhavitoria.com.br/images/bf243440-c25d-0135-7e8d-6231c35b6685--minified.jpg",
+      "title": "Restrições começam a valer em 17 cidades com risco alto no ES",
+      "date": "15/03/2021",
+      "source": "Folha Vitória"
+    },
+    {
+      "id": 14,
+      "href": "https://www.agazeta.com.br/es/cotidiano/coronavirus-matriz-de-risco-do-es-deve-passar-por-mudancas-0321",
+      "target": "_blank",
+      "image": "https://www.saudebusiness.com/sites/saudebusiness.com/files/styles/article_featured_retina/public/uploads/2020/07/woman-in-blue-shirt-wearing-face-mask-3881247-e1594392219265.jpg?itok=nyQ6ndRy",
+      "title": "Coronavírus: Matriz de Risco do ES deve passar por mudanças",
+      "date": "12/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 13,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/03/09/mais-50-mil-doses-de-vacina-contra-a-covid-19-chegam-ao-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/BOgqQlQ4jsNjtZ_x0S4nZaqq7l8=/0x0:700x410/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/Q/d/ocjSx0T1ArcsNRKcwCwQ/doses.jpg",
+      "title": "Mais 50 mil doses de vacina contra a Covid-19 chegam ao ES",
+      "date": "10/03/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 12,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-taxa-de-transmissao-aponta-que-es-tera-aumento-de-internacoes-e-obitos-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/22/chegadas-dos-pacientes-com-covid-19-vindos-de-manaus-404777-article.jpg",
+      "title": "Taxa de transmissão aponta que ES terá aumento de internações e óbitos",
+      "date": "07/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 11,
+      "href": "/news/faixa-etaria-casos-confirmados-covid-es",
+      "target": "_blank",
+      "image": "https://veja.abril.com.br/wp-content/uploads/2020/04/gettyimages-1215609255.jpg",
+      "title": "Veja as principais Faixas Etárias dos casos de Covid-19 no ES",
+      "date": "05/03/2021",
+      "source": "GeoCovid ES"
+    },
+    {
+      "id": 10,
+      "href": "https://www.agazeta.com.br/es/cotidiano/como-estao-os-pacientes-de-outros-estados-transferidos-para-o-es-0321",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/02/07/primeiro-paciente-vindo-de-rondonia-que-chegou-neste-domingo-as-14h-no-aeroporto-de-vitoria-o-paciente-foi-transferido-para-o-hospital-estadual-dr-jayme-santos-neves---415262-article.jpg",
+      "title": "Como estão os pacientes de outros Estados transferidos para o ES",
+      "date": "04/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 9,
+      "href": "https://g1.globo.com/sc/santa-catarina/noticia/2021/03/02/pacientes-de-sc-com-covid-19-serao-transferidos-para-utis-do-es.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/iEQfcvWDHxxv_RtPYn6ejAJ1YnM=/0x0:1140x641/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/t/K/LmbJq8QdC7CjYINxkWZw/hospital-regional-do-oeste-em-chapeco.jpeg",
+      "title": "Governo de Santa Catarina transferirá pacientes com Covid-19 para o ES",
+      "date": "02/03/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 8,
+      "href": "https://www.agazeta.com.br/es/cotidiano/a-terceira-onda-da-covid-foi-anunciada-diz-secretario-de-saude-do-es-0221",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/11/04/secretario-de-estado-da-saude-nesio-fernandes-em-pronunciamento-nesta-quarta-feira-09-353136.jpeg",
+      "title": "\"A terceira onda da Covid foi anunciada\", diz secretário de Saúde do ES",
+      "date": "01/03/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 7,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/02/27/prefeituras-da-grande-vitoria-abrem-vagas-de-agendamento-para-vacinacao-contra-covid-19.ghtml",
+      "target": "_blank",
+      "image": "https://s2.glbimg.com/yGQEALi9gv9NoIdItEJFeybbGhY=/0x0:984x535/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2021/x/J/Vju35wRNATqmGPn5mbqg/esc-vacinacao-19-01-21-cd4710df-1-.jpg",
+      "title": "Cidades da Grande Vitória abrem vagas de agendamento para vacinação contra Covid-19",
+      "date": "01/03/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 6,
+      "href": "https://www.agazeta.com.br/es/cotidiano/por-que-mascaras-com-valvulas-foram-proibidas-nos-voos-no-es-0221",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2020/06/22/empresas-terao-que-adotar-mascaras-no-ambiente-de-trabalhoma-267248-article.jpg",
+      "title": "Por que máscaras com válvulas foram proibidas nos voos no ES?",
+      "date": "24/02/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 5,
+      "href": "https://www.agazeta.com.br/es/cotidiano/prefeituras-do-es-agendam-vacinacao-para-profissionais-fora-da-linha-de-frente-0221",
+      "target": "_blank",
+      "image": "https://midias.agazeta.com.br/2021/01/22/vacina-coronavac-405100-article.jpg",
+      "title": "ES agenda vacinação para profissionais fora da linha de frente",
+      "date": "24/02/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 4,
+      "href": "https://www.agazeta.com.br/es/cotidiano/covid-19-nove-erros-de-higienizacao-que-as-pessoas-ainda-cometem-0221",
+      "target": "",
+      "image": "https://bn1304files.storage.live.com/y4mYN9IFfWDNG5RujMHDRFtefgpWqkTVWscOxaoIOnmdAB4kR8BRNQ1tV7vcjaTiprXy1vigMGyylVda91tb37OpT6pMjRCTdOlEAvR2YiCsc0P-z3DcCKQ2iRlg9zokgtINEjCtjJFn94GuHcWQWN8tcEmLokQTKOJUlCeiI3qe2bOTnxlnEZsMemOjFIvyUsg?width=1024&height=576&cropmode=none",
+      "title": "Covid-19: nove erros de higienização que as pessoas ainda cometem",
+      "date": "18/02/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 3,
+      "href": "https://www.agazeta.com.br/es/cotidiano/mais-dois-pacientes-de-manaus-curados-da-covid-no-es-tem-alta-do-hospital-0221",
+      "target": "",
+      "image": "https://midias.agazeta.com.br/2021/01/22/chegadas-dos-pacientes-com-covid-19-vindos-de-manaus-404792-article.jpg",
+      "title": "Dois pacientes de Manaus curados de Covid-19 no ES",
+      "date": "16/02/2021",
+      "source": "A Gazeta"
+    },
+    {
+      "id": 2,
+      "href": "https://g1.globo.com/es/espirito-santo/noticia/2021/02/06/es-chega-a-5986-mortes-e-301861-casos-confirmados-de-covid-19.ghtml",
+      "target": "",
+      "image": "https://s2.glbimg.com/ObW7kkhOorqEqyqVXSGzZOLGYY0=/0x0:1700x1065/984x0/smart/filters:strip_icc()/i.s3.glbimg.com/v1/AUTH_59edd422c0c84a879bd37670ae4f538a/internal_photos/bs/2020/r/s/q3NLI6RbA57U5eBnGGzA/mortes-coronavirus.jpg",
+      "title": "ES chega a quase 6 mil mortes e 300 mil casos confirmados de Covid-19",
+      "date": "08/02/2021",
+      "source": "G1 - Espírito Santo"
+    },
+    {
+      "id": 1,
+      "href": "/news/retrospectiva-2020-casos-municipios-estado",
+      "target": "",
+      "image": "https://veja.abril.com.br/wp-content/uploads/2020/04/gettyimages-1215609255.jpg",
+      "title": "Retrospestiva de 2020 dos casos de covid-19 no Espírito Santo",
+      "date": "02/02/2021",
+      "source": "GeoCovid ES"
+    }
+  ]
+}

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -36,32 +36,20 @@
 </template>
 
 <script>
+import all_news from 'assets/all_news.json'
+
 export default {
   name: 'NewsPage',
   data() {
     return {
       error: false,
-      loaded: false,
+      loaded: true,
       img: 'https://bn1304files.storage.live.com/y4msLbTAx_Kl9KtXDT2EkixqNbUtlWY1veU5Vy773q080HeS6ZZ3HVKro19IFXPbNhk2jTkcYAE9I1JVx78AnQWKCVLRG09dbBXZkozJV3YE98w4fDlyCDlQZMNcpZ-9GsUOh_YCVfOanDPf0dcx5VsWjvWQGtJkFpawof_SGN7lYfm6jEbydDMCb5RC9Yp4U_O?width=1300&height=600&cropmode=none',
-      allNews: [],
+      allNews: all_news.news,
     }
   },
-  mounted() {
-    this.getNews()
-  },
-  methods: {
-    async getNews() {
-      try {
-        const data = await this.$axios.$get(
-          'https://raw.githubusercontent.com/DevGeocovid/site-data/master/news.json'
-        )
-        Object.assign(this.allNews, data.news)
-      } catch (e) {
-        this.error = true
-      }
-      this.loaded = true
-    },
-  },
+  mounted() {},
+  methods: {},
 }
 </script>
 


### PR DESCRIPTION
- Isso resolverá as notícias não serem carregadas no firefox devido à problemas com acesso Cross-Origin.
- Anteriormente, o site acessava as notícias diretamente no repositório do site-data.